### PR TITLE
Suppress warnings in ARM environments

### DIFF
--- a/include/ProgramOptions.hxx
+++ b/include/ProgramOptions.hxx
@@ -256,10 +256,9 @@ namespace po {
 			return true;
 #ifndef __CHAR_UNSIGNED__
 		if(x >= 0 && y >= 0)
-#else
+#endif
 			if(std::tolower(x) == std::tolower(y))
 				return true;
-#endif
 		return false;
 	}
 

--- a/include/ProgramOptions.hxx
+++ b/include/ProgramOptions.hxx
@@ -254,9 +254,12 @@ namespace po {
 	inline bool case_insensitive_eq(char x, char y) {
 		if(x == y)
 			return true;
+#ifndef __CHAR_UNSIGNED__
 		if(x >= 0 && y >= 0)
+#else
 			if(std::tolower(x) == std::tolower(y))
 				return true;
+#endif
 		return false;
 	}
 


### PR DESCRIPTION
The following warning occurs when using this library in an ARM environment(Raspberry Pi GCC 10.2).

```
../subprojects/ProgramOptions.hxx/include/ProgramOptions.hxx: In function ‘bool po::case_insensitive_eq(char, char)’:
../subprojects/ProgramOptions.hxx/include/ProgramOptions.hxx:257:8: warning: comparison is always true due to limited range of data type [-Wtype-limits]
  257 |   if(x >= 0 && y >= 0)
      |      ~~^~~~
../subprojects/ProgramOptions.hxx/include/ProgramOptions.hxx:257:18: warning: comparison is always true due to limited range of data type [-Wtype-limits]
  257 |   if(x >= 0 && y >= 0)
      |                ~~^~~~
```

The reason for this is that `char` is unsigned in GCC in the ARM environment.

I checked and found that the `__CHAR_UNSIGNED__` macro is provided in this case, so I used it to disable the code that checks if the `char` value is positive.
